### PR TITLE
Allow Slack Team Name in room name

### DIFF
--- a/config/bridge.go
+++ b/config/bridge.go
@@ -183,6 +183,7 @@ func (bc BridgeConfig) FormatBotDisplayname(bot *slack.Bot) string {
 type ChannelNameParams struct {
 	Name string
 	Type database.ChannelType
+	TeamName string
 }
 
 func (bc BridgeConfig) FormatChannelName(params ChannelNameParams) string {

--- a/portal.go
+++ b/portal.go
@@ -1151,6 +1151,7 @@ func (portal *Portal) UpdateName(meta *slack.Channel, sourceTeam *database.UserT
 	formattedName := portal.bridge.Config.Bridge.FormatChannelName(config.ChannelNameParams{
 		Name: plainName,
 		Type: portal.Type,
+		TeamName: sourceTeam.TeamName,
 	})
 
 	return portal.UpdateNameDirect(formattedName) || plainNameChanged


### PR DESCRIPTION
This allows including the Slack server name in the name of Matrix rooms created for bridged channels. 

This is helpful if a user has multiple Slack servers bridged. Each server is probably going to have a "#General" channel. This helps in differentiating them. 

Then, config could look something like: 

```yaml
bridge:
    # Localpart template of MXIDs for Slack users.
    # {{.}} is replaced with the internal ID of the Slack user.
    username_template: slack_{{.}}
    # Displayname template for Slack users.
    # TODO: document variables
    displayname_template: '{{.RealName}} (S)'
    bot_displayname_template: '{{.Name}} (bot)'
    channel_name_template: '#{{.Name}} ({{.TeamName}})'
    portal_message_buffer: 128
    # Should the bridge send a read receipt from the bridge bot when a message has been sent to Slack?
    delivery_receipts: true
```