### PR TITLE
Allow Slack Team Name in room name (formatted)

### DIFF
--- a/config/bridge.go
+++ b/config/bridge.go
@@ -181,8 +181,8 @@ func (bc BridgeConfig) FormatBotDisplayname(bot *slack.Bot) string {
 }
 
 type ChannelNameParams struct {
-	Name string
-	Type database.ChannelType
+	Name     string
+	Type     database.ChannelType
 	TeamName string
 }
 

--- a/portal.go
+++ b/portal.go
@@ -1153,8 +1153,8 @@ func (portal *Portal) UpdateName(meta *slack.Channel, sourceTeam *database.UserT
 	portal.PlainName = plainName
 
 	formattedName := portal.bridge.Config.Bridge.FormatChannelName(config.ChannelNameParams{
-		Name: plainName,
-		Type: portal.Type,
+		Name:     plainName,
+		Type:     portal.Type,
 		TeamName: sourceTeam.TeamName,
 	})
 


### PR DESCRIPTION
Change of the formatting to make it pass the linter, based on #8.

Tried it on my homeserver and appearts to be working.

This is feature is needed when multiple slack accounts are bridge as they are likely to have duplicated channel names, e.g. `#general`. Without this modification, it is not possible to differentiate them unless one click int othe room and inspect the participants in the chat (and know which slack workspace they belong to).