### PR TITLE
allow deleting a portal by it's mxid

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"maunium.net/go/mautrix/bridge/commands"
+	"maunium.net/go/mautrix/id"
 )
 
 type WrappedCommandEvent struct {
@@ -189,11 +190,21 @@ func fnSyncTeams(ce *WrappedCommandEvent) {
 var cmdDeletePortal = &commands.FullHandler{
 	Func:           wrapCommand(fnDeletePortal),
 	Name:           "delete-portal",
-	RequiresPortal: true,
 }
 
 func fnDeletePortal(ce *WrappedCommandEvent) {
-	ce.Portal.delete()
-	ce.Portal.cleanup(false)
+	if len(ce.Args) != 1 && ce.Portal == nil {
+		ce.Reply("**Usage**: $cmdprefix delete-portal <mxid>")
+		return
+	}
+	var portal *Portal
+	if len(ce.Args) == 1 {
+		portal = ce.Bridge.GetPortalByMXID(id.RoomID(ce.Args[0]))
+	} else {
+		portal = ce.Portal
+	}
+
+	portal.delete()
+	portal.cleanup(false)
 	ce.Log.Infofln("Deleted portal")
 }


### PR DESCRIPTION
I had a room where the bot couldn't decrypt my messages due to e2be being broken, needed to be able to do this to get the bot to clean up the room so it would be re-created with encryption turned off