### PR TITLE
Support message attachments legacy fields

### DIFF
--- a/blocks.go
+++ b/blocks.go
@@ -312,7 +312,7 @@ func (portal *Portal) SlackBlocksToMatrix(blocks slack.Blocks, attachments []sla
 			}
 		} else {
 			if len(attachment.Pretext) > 0 {
-				htmlText.WriteString(fmt.Sprintf("%s<br>", portal.mrkdwnToMatrixHtml(attachment.Pretext)))
+				htmlText.WriteString(fmt.Sprintf("<p>%s</p>", portal.mrkdwnToMatrixHtml(attachment.Pretext)))
 			}
 			var attachParts []string
 			if len(attachment.AuthorName) > 0 {
@@ -325,10 +325,10 @@ func (portal *Portal) SlackBlocksToMatrix(blocks slack.Blocks, attachments []sla
 			}
 			if len(attachment.Title) > 0 {
 				if len(attachment.TitleLink) > 0 {
-					attachParts = append(attachParts, fmt.Sprintf("<strong><a href=\"%s\">%s</a></strong>",
+					attachParts = append(attachParts, fmt.Sprintf("<b><a href=\"%s\">%s</a></b>",
 						attachment.TitleLink, portal.mrkdwnToMatrixHtml(attachment.Title)))
 				} else {
-					attachParts = append(attachParts, fmt.Sprintf("<strong>%s</strong>", portal.mrkdwnToMatrixHtml(attachment.Title)))
+					attachParts = append(attachParts, fmt.Sprintf("<b>%s</b>", portal.mrkdwnToMatrixHtml(attachment.Title)))
 				}
 			}
 			if len(attachment.Text) > 0 {
@@ -336,6 +336,7 @@ func (portal *Portal) SlackBlocksToMatrix(blocks slack.Blocks, attachments []sla
 			} else if len(attachment.Fallback) > 0 {
 				attachParts = append(attachParts, portal.mrkdwnToMatrixHtml(attachment.Fallback))
 			}
+			htmlText.WriteString(fmt.Sprintf("<blockquote>%s", strings.Join(attachParts, "<br>")))
 			if len(attachment.Fields) > 0 {
 				var fieldBody string
 				var short = false
@@ -350,7 +351,9 @@ func (portal *Portal) SlackBlocksToMatrix(blocks slack.Blocks, attachments []sla
 						fieldBody += "</tr>"
 					}
 				}
-				attachParts = append(attachParts, fmt.Sprintf("<table>%s</table>", fieldBody))
+				htmlText.WriteString(fmt.Sprintf("<table>%s</table>", fieldBody))
+			} else {
+				htmlText.WriteString("<br>")
 			}
 			var footerParts []string
 			if len(attachment.Footer) > 0 {
@@ -362,9 +365,9 @@ func (portal *Portal) SlackBlocksToMatrix(blocks slack.Blocks, attachments []sla
 				footerParts = append(footerParts, t.Local().Format("Jan 02, 2006 15:04:05 MST"))
 			}
 			if len(footerParts) > 0 {
-				attachParts = append(attachParts, fmt.Sprintf("<sup>%s</sup>", strings.Join(footerParts, " | ")))
+				htmlText.WriteString(fmt.Sprintf("<sup>%s</sup>", strings.Join(footerParts, " | ")))
 			}
-			htmlText.WriteString(fmt.Sprintf("<blockquote>%s</blockquote>", strings.Join(attachParts, "<br>")))
+			htmlText.WriteString("</blockquote>")
 		}
 	}
 

--- a/blocks.go
+++ b/blocks.go
@@ -201,6 +201,19 @@ func (portal *Portal) renderSlackBlock(block slack.Block, userTeam *database.Use
 			htmlText.WriteString(portal.renderSlackRichTextElement(len(b.Elements), element, userTeam))
 		}
 		return format.UnwrapSingleParagraph(htmlText.String()), false
+	case *slack.ContextBlock:
+		var htmlText strings.Builder
+		var unsupported bool = false
+		for _, element := range b.ContextElements.Elements {
+			if mrkdwnElem, ok := element.(*slack.TextBlockObject); ok {
+				htmlText.WriteString(fmt.Sprintf("<sup>%s</sup>", portal.mrkdwnToMatrixHtml(mrkdwnElem.Text)))
+			} else {
+				portal.log.Debugfln("Unsupported Slack block element: %s", element.MixedElementType())
+				htmlText.WriteString("<i>Slack message contains unsupported elements.</i>")
+				unsupported = true
+			}
+		}
+		return htmlText.String(), unsupported
 	default:
 		portal.log.Debugfln("Unsupported Slack block: %s", b.BlockType())
 		return "<i>Slack message contains unsupported elements.</i>", true

--- a/blocks.go
+++ b/blocks.go
@@ -305,6 +305,11 @@ func (portal *Portal) SlackBlocksToMatrix(blocks slack.Blocks, attachments []sla
 				htmlText.WriteString(fmt.Sprintf("<blockquote><b>%s</b><br>%s<a href=\"%s\"><i>%s</i></a><br></blockquote>",
 					attachment.AuthorName, renderedAttachment, attachment.FromURL, attachment.Footer))
 			}
+		} else if len(attachment.Blocks.BlockSet) > 0 {
+			for _, message_block := range attachment.Blocks.BlockSet {
+				renderedAttachment, _ := portal.renderSlackBlock(message_block, userTeam)
+				htmlText.WriteString(fmt.Sprintf("<blockquote>%s</blockquote>", renderedAttachment))
+			}
 		} else {
 			if len(attachment.Pretext) > 0 {
 				htmlText.WriteString(fmt.Sprintf("%s<br>", portal.mrkdwnToMatrixHtml(attachment.Pretext)))


### PR DESCRIPTION
As documented at https://api.slack.com/reference/messaging/attachments

Some bots that are used at my employer use the legacy attachments formatting instead of blocks so I hacked this in.  
This should probably be a separate function and could be refactored to reduce some nesting, but this is what I'm running right now.

The current version is missing support for the following items because I haven't got around to handle images inside messages but it shouldn't be too hard to implement by refactoring `renderImageBlock` a bit:

- author_icon
- footer_icon
- image_url
- thumb_url

Not sure if this warrants a draft to wait until images are handled or if this can be added as is (after review).