### PR TITLE
fix(sync-teams): 'IS NULL' instead of '= NULL'

### DIFF
--- a/database/user.go
+++ b/database/user.go
@@ -75,7 +75,7 @@ func (u *User) SyncTeams() {
 	}
 
 	// Delete not logged in teams from the database.
-	query := "DELETE FROM user_team WHERE mxid=$1 AND token=NULL"
+	query := "DELETE FROM user_team WHERE mxid=$1 AND token IS NULL"
 
 	_, err := u.db.Exec(query, u.MXID)
 	if err != nil {


### PR DESCRIPTION
Correctly removes `user_team` records that have null tokens.

The existing implementation of using `=NULL` in the query always results in a false negative. Correcting the syntax ensures the records without tokens are correctly deleted when calling `SyncTeams`.