### PR TITLE
login: Fix repeated set of location.href

### DIFF
--- a/pkg/connector/login-cookie.go
+++ b/pkg/connector/login-cookie.go
@@ -65,15 +65,15 @@ var _ bridgev2.LoginProcessCookies = (*SlackTokenLogin)(nil)
 
 const ExtractSlackTokenJS = `
 new Promise(resolve => {
-	let mautrixSlackTokenCheckInterval;
-	let useSlackInBrowserClicked = false;
+	let mautrixSlackTokenCheckInterval
+	let useSlackInBrowserClicked = false
 	function mautrixFindSlackToken() {
 		// Automatically click the "Use Slack in Browser" button
 		if (/\.slack\.com$/.test(window.location.host)) {
-			const link = document?.querySelector?.(".p-ssb_redirect__body")?.querySelector?.(".c-link");
+			const link = document?.querySelector?.(".p-ssb_redirect__body")?.querySelector?.(".c-link")
 			if (link && !useSlackInBrowserClicked) {
-				location.href = link.getAttribute("href");
-				useSlackInBrowserClicked = true;
+				location.href = link.getAttribute("href")
+				useSlackInBrowserClicked = true
 			}
 		}
 		if (!localStorage.localConfig_v2?.includes("xoxc-")) {

--- a/pkg/connector/login-cookie.go
+++ b/pkg/connector/login-cookie.go
@@ -65,13 +65,15 @@ var _ bridgev2.LoginProcessCookies = (*SlackTokenLogin)(nil)
 
 const ExtractSlackTokenJS = `
 new Promise(resolve => {
-	let mautrixSlackTokenCheckInterval
+	let mautrixSlackTokenCheckInterval;
+	let useSlackInBrowserClicked = false;
 	function mautrixFindSlackToken() {
 		// Automatically click the "Use Slack in Browser" button
 		if (/\.slack\.com$/.test(window.location.host)) {
 			const link = document?.querySelector?.(".p-ssb_redirect__body")?.querySelector?.(".c-link");
-			if (link) {
+			if (link && !useSlackInBrowserClicked) {
 				location.href = link.getAttribute("href");
+				useSlackInBrowserClicked = true;
 			}
 		}
 		if (!localStorage.localConfig_v2?.includes("xoxc-")) {


### PR DESCRIPTION
This causes the navigation to entirely fail when used in WKWebView. Setting `location.href` once still works and fixes the issue.

When setting `location.href` repeatedly, the older request is cancelled.