### PR TITLE
Accurately represent Matrix messages containing newlines in Slack

### DIFF
--- a/pkg/msgconv/matrixfmt/blocks.go
+++ b/pkg/msgconv/matrixfmt/blocks.go
@@ -451,10 +451,11 @@ func (parser *HTMLParser) nodeToBlock(node *html.Node, ctx Context) *slack.RichT
 
 func (parser *HTMLParser) ParseText(ctx context.Context, text string, mentions *event.Mentions, portal *bridgev2.Portal) *slack.RichTextBlock {
 	formatCtx := Context{
-		Ctx:      ctx,
-		TagStack: make(format.TagStack, 0),
-		Portal:   portal,
-		Mentions: mentions,
+		Ctx:                ctx,
+		TagStack:           make(format.TagStack, 0),
+		Portal:             portal,
+		Mentions:           mentions,
+		PreserveWhitespace: true,
 	}
 	elems := parser.textToElements(text, formatCtx)
 	return slack.NewRichTextBlock("", slack.NewRichTextSection(elems...))


### PR DESCRIPTION
Newlines don't seem to be replicated correctly in slack when sent from matrix as text.

Set the `PreserveWhitespace` field in the format `Context` to preserve newlines as expected. Without this field, all `"\n"`s are stripped from the text during parsing, resulting in some odd-looking messages in slack.

Before:
(matrix)
![newline-matrix-before](https://github.com/user-attachments/assets/f54a68c7-4265-4eff-8259-0fc57e9849d0)
(slack)
![newline-slack-before](https://github.com/user-attachments/assets/c5073a8e-a370-4809-891f-c70576afa447)

After:
(matrix)
![newline-matrix-after](https://github.com/user-attachments/assets/eedfd449-401e-4e36-8f1c-d189c620384d)
(slack)
![newline-slack-after](https://github.com/user-attachments/assets/be41be18-9e7e-4a8d-bf8f-8a8195a23a11)
