### PR TITLE
Fix historical thread message order during backfill

### DIFF
--- a/pkg/connector/backfill.go
+++ b/pkg/connector/backfill.go
@@ -106,7 +106,12 @@ func (s *SlackClient) FetchMessages(ctx context.Context, params bridgev2.FetchMe
 			maxMsgID = msg.Timestamp
 		}
 	}
-	slices.Reverse(convertedMessages)
+
+	// Reverse converted messages order for non-thread messages.
+	if params.ThreadRoot == "" {
+		slices.Reverse(convertedMessages)
+	}
+
 	lastRead := s.getLastReadCache(channelID)
 	return &bridgev2.FetchMessagesResponse{
 		Messages: convertedMessages,


### PR DESCRIPTION
Fix thread order when backfilling history.

Currently when backfilling, the bridge seems to post thread messages in reverse chronological order.
Slack thread:
![thread-order-slack](https://github.com/user-attachments/assets/42a6e0d2-4464-4700-bcbf-e2b323b22d02)

Matrix thread backfilled before this change:
![thread-order-mautrix-slack-main](https://github.com/user-attachments/assets/05959d32-0234-4bc5-a6e9-67b700612c7d)

Preventing the `convertedMessages` slice from being reversed for threads results in threads appearing in the expected order:
Matrix thread backfilled after this change:
![thread-order-mautrix-slack-fix](https://github.com/user-attachments/assets/8c94544b-0534-4475-bff8-acff031d1fe6)
