### PR TITLE
Dedicated user-agent

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -20,6 +20,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"net/http"
 	"slices"
 	"strings"
 	"sync"
@@ -46,10 +47,23 @@ func init() {
 	})
 }
 
+type wrapFuncAsRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f wrapFuncAsRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
 func makeSlackClient(log *zerolog.Logger, token, cookieToken, appToken string) *slack.Client {
+	httpClient := &http.Client{}
+	httpClient.Transport = wrapFuncAsRoundTripper(func(req *http.Request) (*http.Response, error) {
+		r := req.Clone(req.Context())
+		r.Header.Set("User-Agent", "SlackWeb/0 mautrix-slack/0 Go-http-client/2.0")
+		return http.DefaultTransport.RoundTrip(r)
+	})
 	options := []slack.Option{
 		slack.OptionLog(slackgoZerolog{Logger: log.With().Str("component", "slackgo").Logger()}),
 		slack.OptionDebug(log.GetLevel() == zerolog.TraceLevel),
+		slack.OptionHTTPClient(httpClient),
 	}
 	if cookieToken != "" {
 		options = append(options, slack.OptionCookie("d", cookieToken))


### PR DESCRIPTION
<!-- Make sure you read the contributing guidelines first:
https://docs.mau.fi/bridges/general/contributing.html -->

Hi. This pull request adds the User-Agent snippet `mautrix-slack/0` to the User-Agent used by the bridge. This lets communities choose to whitelist the bot with the Slack moderation tools.

This change was suggested by a member of the [Mac Admins group](https://github.com/macadminsdotorg/codeofconduct/blob/master/Code_of_Conduct.md#11-privacy-and-data-retention), who blacklist the standard `Go-http-client/2.0` as it is commonly used by AI/LLM/quant/whatever scrapers which compromise the privacy of their communities.

Slack allows any User-Agent so long as it includes the `SlackWeb/0` snippet.