### PR TITLE
chatinfo: don't use batch user resync queue for bot IDs

### DIFF
--- a/pkg/connector/chatinfo.go
+++ b/pkg/connector/chatinfo.go
@@ -468,10 +468,12 @@ func (s *SlackClient) GetUserInfo(ctx context.Context, ghost *bridgev2.Ghost) (*
 	if time.Since(meta.LastSync.Time) < MinGhostSyncInterval {
 		return nil, nil
 	}
-	if s.IsRealUser && (ghost.Name != "" || time.Since(s.initialConnect) < 1*time.Minute) {
+	_, userID := slackid.ParseUserID(ghost.ID)
+	// Don't batch-queue B-prefix bot IDs: GetUsersCacheContext is a users-only API
+	// that silently ignores them, so they must go through fetchUserInfo → GetBotInfoContext.
+	if s.IsRealUser && userID[0] != 'B' && (ghost.Name != "" || time.Since(s.initialConnect) < 1*time.Minute) {
 		s.userResyncQueue <- ghost
 		return nil, nil
 	}
-	_, userID := slackid.ParseUserID(ghost.ID)
 	return s.fetchUserInfo(ctx, userID, meta.SlackUpdatedTS, ghost)
 }


### PR DESCRIPTION
## Problem

B-prefix bot/app ghost IDs (e.g. `BGT7QUP3L` for Google Drive) on cookie-based logins (`IsRealUser = true`) never get `IsBot` set to `true`, so `com.beeper.bridge.is_network_bot` is permanently `false`.

This causes clients to include Slack app bots in `nonBotMembers`, making them appear as the DM partner instead of the actual human contact.

## Cause

`GetUserInfo` unconditionally routes all named ghosts to `userResyncQueue` on cookie-based logins. The queue consumer calls `syncManyUsers` → `GetUsersCacheContext`, which is a users-only Slack API that silently ignores B-prefix bot IDs. So `wrapUserInfo` is never called for bots and `IsBot` stays `false`.

The correct path (`fetchUserInfo` → `GetBotInfoContext`) exists but is dead code for cookie logins once a ghost has a name.

## Fix

Skip the batch queue for B-prefix IDs so they fall through to `fetchUserInfo`, which correctly calls `GetBotInfoContext` and sets `isBot = true`. This matches the existing `userID[0] == 'B'` check already used in `fetchUserInfo` (line 432).