### PR TITLE
Fix broken ROADMAP link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ All setup and usage instructions are located on [docs.mau.fi]. Some quick links:
 * Basic usage: [Authentication](https://docs.mau.fi/bridges/go/slack/authentication.html)
 
 ### Features & Roadmap
-[ROADMAP.md](https://github.com/mautrix/slack/blob/master/ROADMAP.md)
+[ROADMAP.md](https://github.com/mautrix/slack/blob/main/ROADMAP.md)
 contains a general overview of what is supported by the bridge.
 
 ## Discussion


### PR DESCRIPTION
This PR fixes a broken link the README. It was pointing at the `master` branch which no longer exists, so I suspect this wasn't updated after changing to `main`.

### Checklist

* [x] I have read and followed the contributing guidelines at <>
