### PR TITLE
msgconv: preserve Slack user group mentions

### DIFF
--- a/pkg/msgconv/blocks.go
+++ b/pkg/msgconv/blocks.go
@@ -299,6 +299,10 @@ func (mc *MessageConverter) renderRichTextSectionElements(
 			openingTags(&htmlText, e.Style)
 			mrkdwn.RoomMentionToHTML(&htmlText, e.ChannelID, mxid, alias, name, mc.ServerName)
 			closingTags(&htmlText, e.Style)
+		case *slack.RichTextSectionUserGroupElement:
+			openingTags(&htmlText, e.Style)
+			mrkdwn.UserGroupMentionToHTML(&htmlText, e.UsergroupID, "")
+			closingTags(&htmlText, e.Style)
 		case *slack.RichTextSectionLinkElement:
 			var linkText string
 			if e.Text != "" {

--- a/pkg/msgconv/blocks_test.go
+++ b/pkg/msgconv/blocks_test.go
@@ -86,6 +86,27 @@ func TestSlackBlocksToMatrixMessageMention(t *testing.T) {
 	}
 }
 
+func TestSlackBlocksToMatrixUserGroupMention(t *testing.T) {
+	mc := testMessageConverter()
+	part, err := mc.slackBlocksToMatrix(context.Background(), nil, nil, slack.Blocks{
+		BlockSet: []slack.Block{
+			slack.NewRichTextBlock("", slack.NewRichTextSection(
+				slack.NewRichTextSectionTextElement("Hi ", nil),
+				slack.NewRichTextSectionUserGroupElement("S123"),
+			)),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if part.Content.Body != "Hi <!subteam^S123>" {
+		t.Fatalf("unexpected body: %q", part.Content.Body)
+	}
+	if part.Content.FormattedBody != "Hi &lt;!subteam^S123&gt;" {
+		t.Fatalf("unexpected formatted body: %q", part.Content.FormattedBody)
+	}
+}
+
 func TestSlackBlocksToMatrixMessageMentionPermalink(t *testing.T) {
 	mc := testMessageConverter()
 	part, err := mc.slackBlocksToMatrix(context.Background(), nil, nil, slack.Blocks{

--- a/pkg/msgconv/mrkdwn/tag.go
+++ b/pkg/msgconv/mrkdwn/tag.go
@@ -166,7 +166,6 @@ func (s *slackTagParser) Parse(parent ast.Node, block text.Reader, pc parser.Con
 		switch content {
 		case "channel", "everyone", "here":
 			pc.Get(ContextKeyMentions).(*event.Mentions).Room = true
-		default:
 		}
 		return &astSlackSpecialMention{astSlackTag: tag, content: content}
 	case "":
@@ -205,6 +204,16 @@ func RoomMentionToHTML(out io.Writer, channelID string, mxid id.RoomID, alias id
 		_, _ = fmt.Fprintf(out, "%s", name)
 	} else {
 		_, _ = fmt.Fprintf(out, "&lt;#%s&gt;", channelID)
+	}
+}
+
+func UserGroupMentionToHTML(out io.Writer, userGroupID, name string) {
+	if name == "" {
+		_, _ = fmt.Fprintf(out, "&lt;!subteam^%s&gt;", html.EscapeString(userGroupID))
+	} else if strings.HasPrefix(name, "@") {
+		_, _ = io.WriteString(out, html.EscapeString(name))
+	} else {
+		_, _ = fmt.Fprintf(out, "@%s", html.EscapeString(name))
 	}
 }
 
@@ -256,7 +265,9 @@ func (r *slackTagHTMLRenderer) renderSlackTag(w goldmarkUtil.BufWriter, source [
 			// do @room mentions?
 			return
 		case "subteam":
-			// do subteam handling? more spaces?
+			if len(parts) > 1 {
+				UserGroupMentionToHTML(w, parts[1], node.label)
+			}
 			return
 		default:
 			return

--- a/pkg/msgconv/mrkdwn/tag_test.go
+++ b/pkg/msgconv/mrkdwn/tag_test.go
@@ -1,0 +1,55 @@
+// mautrix-slack - A Matrix-Slack puppeting bridge.
+// Copyright (C) 2024 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package mrkdwn
+
+import (
+	"context"
+	"testing"
+
+	"maunium.net/go/mautrix/event"
+)
+
+func TestUserGroupMention(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "embedded label",
+			input:    "Hi <!subteam^S123|@platform-team>",
+			expected: "Hi @platform-team",
+		},
+		{
+			name:     "raw fallback",
+			input:    "Hi <!subteam^S404>",
+			expected: "Hi &lt;!subteam^S404&gt;",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parser := New(&Params{})
+			output, err := parser.Parse(context.Background(), test.input, &event.Mentions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if output != test.expected {
+				t.Fatalf("unexpected output: %q", output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- render labeled Slack `<!subteam^ID|@handle>` mentions as `@handle`
- preserve unlabeled mrkdwn and rich-text user-group mentions as visible `<!subteam^ID>` fallbacks instead of dropping them
- avoid API lookups, caching, new OAuth scopes, and reauthorization requirements

Slack commonly provides only the user-group ID, including in rich-text `usergroup` elements. Resolving those IDs to handles can be handled separately if desired; this PR is intentionally limited to lossless conversion.

## Testing

- `go test -count=1 ./pkg/connector ./pkg/msgconv/...`
- `go test -race -count=1 ./pkg/connector ./pkg/msgconv/...`

Fixes #90