### PR TITLE
connector: resolve Slack user group mention handles

### DIFF
--- a/app-manifest.yaml
+++ b/app-manifest.yaml
@@ -35,6 +35,7 @@ oauth_config:
       - reactions:read
       - reactions:write
       - team:read
+      - usergroups:read
       - users:read
       - users.profile:read
       - users:read.email

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -109,6 +109,12 @@ type chatInfoCacheEntry struct {
 	data *slack.Channel
 }
 
+type userGroupInfoCache struct {
+	updatedAt   time.Time
+	lastAttempt time.Time
+	data        map[string]string
+}
+
 type SlackClient struct {
 	Main       *SlackConnector
 	UserLogin  *bridgev2.UserLogin
@@ -132,6 +138,8 @@ type SlackClient struct {
 	chatInfoCache          map[string]chatInfoCacheEntry
 	chatInfoFetchAttempted map[string]bool
 	chatInfoCacheLock      sync.Mutex
+	userGroupInfoCache     userGroupInfoCache
+	userGroupInfoCacheLock sync.Mutex
 	lastReadCache          map[string]string
 	lastReadCacheLock      sync.Mutex
 }

--- a/pkg/connector/usergroups.go
+++ b/pkg/connector/usergroups.go
@@ -1,0 +1,62 @@
+// mautrix-slack - A Matrix-Slack puppeting bridge.
+// Copyright (C) 2024 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package connector
+
+import (
+	"context"
+	"time"
+
+	"github.com/slack-go/slack"
+)
+
+const UserGroupInfoCacheExpiry = 1 * time.Hour
+const UserGroupInfoRetryInterval = 1 * time.Minute
+const UserGroupInfoRequestTimeout = 10 * time.Second
+
+func (s *SlackClient) GetUserGroupInfoForMention(ctx context.Context, userGroupID string) (string, error) {
+	s.userGroupInfoCacheLock.Lock()
+	defer s.userGroupInfoCacheLock.Unlock()
+
+	now := time.Now()
+	handle, found := s.userGroupInfoCache.data[userGroupID]
+	cacheExpired := now.Sub(s.userGroupInfoCache.updatedAt) >= UserGroupInfoCacheExpiry
+	canRetry := now.Sub(s.userGroupInfoCache.lastAttempt) >= UserGroupInfoRetryInterval
+	if (!found || cacheExpired) && canRetry {
+		if err := ctx.Err(); err != nil {
+			return handle, err
+		}
+		s.userGroupInfoCache.lastAttempt = now
+		fetchCtx, cancel := context.WithTimeout(ctx, UserGroupInfoRequestTimeout)
+		defer cancel()
+		groups, err := s.Client.GetUserGroupsContext(
+			fetchCtx,
+			slack.GetUserGroupsOptionTeamID(s.TeamID),
+			slack.GetUserGroupsOptionIncludeDisabled(true),
+		)
+		if err != nil {
+			return handle, err
+		}
+		cache := make(map[string]string, len(groups))
+		for _, group := range groups {
+			cache[group.ID] = group.Handle
+		}
+		s.userGroupInfoCache.updatedAt = time.Now()
+		s.userGroupInfoCache.data = cache
+		handle = cache[userGroupID]
+	}
+	return handle, nil
+}

--- a/pkg/connector/usergroups_test.go
+++ b/pkg/connector/usergroups_test.go
@@ -1,0 +1,127 @@
+// mautrix-slack - A Matrix-Slack puppeting bridge.
+// Copyright (C) 2024 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package connector
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+)
+
+func newUserGroupTestClient(t *testing.T, handler http.HandlerFunc) *SlackClient {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return &SlackClient{
+		Client: slack.New("testing-token", slack.OptionAPIURL(server.URL+"/")),
+		TeamID: "T123",
+	}
+}
+
+func TestGetUserGroupInfoForMentionCachesAndRefreshes(t *testing.T) {
+	requests := 0
+	handle := "platform-team"
+	client := newUserGroupTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/usergroups.list" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.FormValue("team_id") != "T123" || r.FormValue("include_disabled") != "true" {
+			t.Errorf("unexpected request parameters: %s", r.Form.Encode())
+		}
+		_, _ = fmt.Fprintf(w, `{"ok":true,"usergroups":[{"id":"S123","handle":%q}]}`, handle)
+	})
+
+	for range 2 {
+		name, err := client.GetUserGroupInfoForMention(context.Background(), "S123")
+		if err != nil || name != "platform-team" {
+			t.Fatalf("unexpected cached result: name=%q, err=%v", name, err)
+		}
+	}
+	if requests != 1 {
+		t.Fatalf("expected 1 request, got %d", requests)
+	}
+
+	client.userGroupInfoCache.updatedAt = time.Now().Add(-UserGroupInfoCacheExpiry)
+	client.userGroupInfoCache.lastAttempt = time.Now().Add(-UserGroupInfoRetryInterval)
+	handle = "renamed-team"
+	name, err := client.GetUserGroupInfoForMention(context.Background(), "S123")
+	if err != nil || name != "renamed-team" {
+		t.Fatalf("unexpected refreshed result: name=%q, err=%v", name, err)
+	}
+	if requests != 2 {
+		t.Fatalf("expected 2 requests, got %d", requests)
+	}
+}
+
+func TestGetUserGroupInfoForMentionRetainsStaleDataAndBacksOff(t *testing.T) {
+	requests := 0
+	fail := false
+	client := newUserGroupTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if fail {
+			_, _ = fmt.Fprint(w, `{"ok":false,"error":"request_timeout"}`)
+		} else {
+			_, _ = fmt.Fprint(w, `{"ok":true,"usergroups":[{"id":"S123","handle":"platform-team"}]}`)
+		}
+	})
+
+	name, err := client.GetUserGroupInfoForMention(context.Background(), "S123")
+	if err != nil || name != "platform-team" {
+		t.Fatalf("unexpected initial result: name=%q, err=%v", name, err)
+	}
+
+	client.userGroupInfoCache.updatedAt = time.Now().Add(-UserGroupInfoCacheExpiry)
+	client.userGroupInfoCache.lastAttempt = time.Now().Add(-UserGroupInfoRetryInterval)
+	fail = true
+	name, err = client.GetUserGroupInfoForMention(context.Background(), "S123")
+	if err == nil || name != "platform-team" {
+		t.Fatalf("expected stale handle with refresh error, got name=%q, err=%v", name, err)
+	}
+	name, err = client.GetUserGroupInfoForMention(context.Background(), "S123")
+	if err != nil || name != "platform-team" {
+		t.Fatalf("expected stale handle during backoff, got name=%q, err=%v", name, err)
+	}
+	if requests != 2 {
+		t.Fatalf("expected 2 requests, got %d", requests)
+	}
+}
+
+func TestGetUserGroupInfoForMentionDoesNotBackOffCanceledContext(t *testing.T) {
+	client := newUserGroupTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{"ok":true,"usergroups":[{"id":"S123","handle":"platform-team"}]}`)
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := client.GetUserGroupInfoForMention(ctx, "S123")
+	if err == nil {
+		t.Fatal("expected canceled request to fail")
+	}
+	if !client.userGroupInfoCache.lastAttempt.IsZero() {
+		t.Fatal("canceled context unexpectedly started backoff")
+	}
+
+	name, err := client.GetUserGroupInfoForMention(context.Background(), "S123")
+	if err != nil || name != "platform-team" {
+		t.Fatalf("unexpected retry result: name=%q, err=%v", name, err)
+	}
+}

--- a/pkg/msgconv/blocks.go
+++ b/pkg/msgconv/blocks.go
@@ -301,7 +301,7 @@ func (mc *MessageConverter) renderRichTextSectionElements(
 			closingTags(&htmlText, e.Style)
 		case *slack.RichTextSectionUserGroupElement:
 			openingTags(&htmlText, e.Style)
-			mrkdwn.UserGroupMentionToHTML(&htmlText, e.UsergroupID, "")
+			mrkdwn.UserGroupMentionToHTML(&htmlText, e.UsergroupID, mc.GetMentionedUserGroupInfo(ctx, e.UsergroupID))
 			closingTags(&htmlText, e.Style)
 		case *slack.RichTextSectionLinkElement:
 			var linkText string

--- a/pkg/msgconv/blocks.go
+++ b/pkg/msgconv/blocks.go
@@ -299,6 +299,10 @@ func (mc *MessageConverter) renderRichTextSectionElements(
 			openingTags(&htmlText, e.Style)
 			mrkdwn.RoomMentionToHTML(&htmlText, e.ChannelID, mxid, alias, name, mc.ServerName)
 			closingTags(&htmlText, e.Style)
+		case *slack.RichTextSectionUserGroupElement:
+			openingTags(&htmlText, e.Style)
+			mrkdwn.UserGroupMentionToHTML(&htmlText, e.UsergroupID, "")
+			closingTags(&htmlText, e.Style)
 		case *slack.RichTextSectionLinkElement:
 			var linkText string
 			if e.Text != "" {

--- a/pkg/msgconv/blocks_test.go
+++ b/pkg/msgconv/blocks_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/slack-go/slack"
+	"maunium.net/go/mautrix/bridgev2"
 
 	"go.mau.fi/mautrix-slack/pkg/msgconv/mrkdwn"
 )
@@ -13,6 +14,29 @@ func testMessageConverter() *MessageConverter {
 	return &MessageConverter{
 		SlackMrkdwnParser: mrkdwn.New(&mrkdwn.Params{}),
 	}
+}
+
+type testUserGroupClient struct {
+	bridgev2.NetworkAPI
+	handle      string
+	requestedID string
+}
+
+func (tugc *testUserGroupClient) GetClient() *slack.Client {
+	return nil
+}
+
+func (tugc *testUserGroupClient) GetEmoji(context.Context, string) (string, bool) {
+	return "", false
+}
+
+func (tugc *testUserGroupClient) GetChannelInfoForMention(context.Context, string) (string, *bridgev2.Portal, error) {
+	return "", nil, nil
+}
+
+func (tugc *testUserGroupClient) GetUserGroupInfoForMention(_ context.Context, userGroupID string) (string, error) {
+	tugc.requestedID = userGroupID
+	return tugc.handle, nil
 }
 
 func TestSlackBlocksToMatrixMessageUnfurlFallback(t *testing.T) {
@@ -88,7 +112,9 @@ func TestSlackBlocksToMatrixMessageMention(t *testing.T) {
 
 func TestSlackBlocksToMatrixUserGroupMention(t *testing.T) {
 	mc := testMessageConverter()
-	part, err := mc.slackBlocksToMatrix(context.Background(), nil, nil, slack.Blocks{
+	client := &testUserGroupClient{handle: "platform-team"}
+	ctx := context.WithValue(context.Background(), contextKeySource, &bridgev2.UserLogin{Client: client})
+	part, err := mc.slackBlocksToMatrix(ctx, nil, nil, slack.Blocks{
 		BlockSet: []slack.Block{
 			slack.NewRichTextBlock("", slack.NewRichTextSection(
 				slack.NewRichTextSectionTextElement("Hi ", nil),
@@ -99,10 +125,13 @@ func TestSlackBlocksToMatrixUserGroupMention(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if part.Content.Body != "Hi <!subteam^S123>" {
+	if client.requestedID != "S123" {
+		t.Fatalf("unexpected requested ID: %q", client.requestedID)
+	}
+	if part.Content.Body != "Hi @platform-team" {
 		t.Fatalf("unexpected body: %q", part.Content.Body)
 	}
-	if part.Content.FormattedBody != "Hi &lt;!subteam^S123&gt;" {
+	if part.Content.FormattedBody != "" {
 		t.Fatalf("unexpected formatted body: %q", part.Content.FormattedBody)
 	}
 }

--- a/pkg/msgconv/blocks_test.go
+++ b/pkg/msgconv/blocks_test.go
@@ -86,6 +86,27 @@ func TestSlackBlocksToMatrixMessageMention(t *testing.T) {
 	}
 }
 
+func TestSlackBlocksToMatrixUserGroupMention(t *testing.T) {
+	mc := testMessageConverter()
+	part, err := mc.slackBlocksToMatrix(context.Background(), nil, nil, slack.Blocks{
+		BlockSet: []slack.Block{
+			slack.NewRichTextBlock("", slack.NewRichTextSection(
+				slack.NewRichTextSectionTextElement("Hi ", nil),
+				slack.NewRichTextSectionUserGroupElement("S123"),
+			)),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if part.Content.Body != "Hi <!subteam^S123>" {
+		t.Fatalf("unexpected body: %q", part.Content.Body)
+	}
+	if part.Content.FormattedBody != "Hi &lt;!subteam^S123&gt;" {
+		t.Fatalf("unexpected formatted body: %q", part.Content.FormattedBody)
+	}
+}
+
 func TestSlackBlocksToMatrixMessageMentionPermalink(t *testing.T) {
 	mc := testMessageConverter()
 	part, err := mc.slackBlocksToMatrix(context.Background(), nil, nil, slack.Blocks{

--- a/pkg/msgconv/mrkdwn/tag.go
+++ b/pkg/msgconv/mrkdwn/tag.go
@@ -166,7 +166,6 @@ func (s *slackTagParser) Parse(parent ast.Node, block text.Reader, pc parser.Con
 		switch content {
 		case "channel", "everyone", "here":
 			pc.Get(ContextKeyMentions).(*event.Mentions).Room = true
-		default:
 		}
 		return &astSlackSpecialMention{astSlackTag: tag, content: content}
 	case "":
@@ -205,6 +204,16 @@ func RoomMentionToHTML(out io.Writer, channelID string, mxid id.RoomID, alias id
 		_, _ = fmt.Fprintf(out, "%s", name)
 	} else {
 		_, _ = fmt.Fprintf(out, "&lt;#%s&gt;", channelID)
+	}
+}
+
+func UserGroupMentionToHTML(out io.Writer, userGroupID, name string) {
+	if name == "" {
+		_, _ = fmt.Fprintf(out, "&lt;!subteam^%s&gt;", html.EscapeString(userGroupID))
+	} else if strings.HasPrefix(name, "@") {
+		_, _ = io.WriteString(out, html.EscapeString(name))
+	} else {
+		_, _ = fmt.Fprintf(out, "@%s", html.EscapeString(name))
 	}
 }
 
@@ -256,7 +265,9 @@ func (r *slackTagHTMLRenderer) renderSlackTag(w goldmarkUtil.BufWriter, source [
 			// do @room mentions?
 			return
 		case "subteam":
-			// do subteam handling? more spaces?
+			if len(parts) > 1 {
+				UserGroupMentionToHTML(w, parts[1], node.label)
+			}
 			return
 		default:
 			return

--- a/pkg/msgconv/mrkdwn/tag.go
+++ b/pkg/msgconv/mrkdwn/tag.go
@@ -104,7 +104,8 @@ func (n *astSlackURL) String() string {
 type astSlackSpecialMention struct {
 	astSlackTag
 
-	content string
+	content      string
+	resolvedName string
 }
 
 func (n *astSlackSpecialMention) String() string {
@@ -116,9 +117,17 @@ func (n *astSlackSpecialMention) String() string {
 }
 
 type Params struct {
-	ServerName     string
-	GetUserInfo    func(ctx context.Context, userID string) (mxid id.UserID, name string)
-	GetChannelInfo func(ctx context.Context, channelID string) (mxid id.RoomID, alias id.RoomAlias, name string)
+	ServerName       string
+	GetUserInfo      func(ctx context.Context, userID string) (mxid id.UserID, name string)
+	GetChannelInfo   func(ctx context.Context, channelID string) (mxid id.RoomID, alias id.RoomAlias, name string)
+	GetUserGroupInfo func(ctx context.Context, userGroupID string) string
+}
+
+func (p *Params) GetUserGroupName(ctx context.Context, userGroupID string) string {
+	if p.GetUserGroupInfo == nil {
+		return ""
+	}
+	return p.GetUserGroupInfo(ctx, userGroupID)
 }
 
 type slackTagParser struct {
@@ -163,11 +172,15 @@ func (s *slackTagParser) Parse(parent ast.Node, block text.Reader, pc parser.Con
 		mxid, alias, name := s.GetChannelInfo(ctx, content)
 		return &astSlackChannelMention{astSlackTag: tag, channelID: content, serverName: s.ServerName, mxid: mxid, alias: alias, name: name}
 	case "!":
+		resolvedName := ""
+		if userGroupID, ok := strings.CutPrefix(content, "subteam^"); ok && tag.label == "" {
+			resolvedName = s.GetUserGroupName(ctx, userGroupID)
+		}
 		switch content {
 		case "channel", "everyone", "here":
 			pc.Get(ContextKeyMentions).(*event.Mentions).Room = true
 		}
-		return &astSlackSpecialMention{astSlackTag: tag, content: content}
+		return &astSlackSpecialMention{astSlackTag: tag, content: content, resolvedName: resolvedName}
 	case "":
 		return &astSlackURL{astSlackTag: tag, url: content}
 	default:
@@ -266,7 +279,11 @@ func (r *slackTagHTMLRenderer) renderSlackTag(w goldmarkUtil.BufWriter, source [
 			return
 		case "subteam":
 			if len(parts) > 1 {
-				UserGroupMentionToHTML(w, parts[1], node.label)
+				name := node.label
+				if name == "" {
+					name = node.resolvedName
+				}
+				UserGroupMentionToHTML(w, parts[1], name)
 			}
 			return
 		default:

--- a/pkg/msgconv/mrkdwn/tag_test.go
+++ b/pkg/msgconv/mrkdwn/tag_test.go
@@ -25,9 +25,11 @@ import (
 
 func TestUserGroupMention(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected string
+		name         string
+		input        string
+		resolvedName string
+		expectedID   string
+		expected     string
 	}{
 		{
 			name:     "embedded label",
@@ -35,20 +37,35 @@ func TestUserGroupMention(t *testing.T) {
 			expected: "Hi @platform-team",
 		},
 		{
-			name:     "raw fallback",
-			input:    "Hi <!subteam^S404>",
-			expected: "Hi &lt;!subteam^S404&gt;",
+			name:         "resolved handle",
+			input:        "Hi <!subteam^S123>",
+			resolvedName: "platform-team",
+			expectedID:   "S123",
+			expected:     "Hi @platform-team",
+		},
+		{
+			name:       "unresolved fallback",
+			input:      "Hi <!subteam^S404>",
+			expectedID: "S404",
+			expected:   "Hi &lt;!subteam^S404&gt;",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			parser := New(&Params{})
+			requestedID := ""
+			parser := New(&Params{GetUserGroupInfo: func(_ context.Context, userGroupID string) string {
+				requestedID = userGroupID
+				return test.resolvedName
+			}})
 			output, err := parser.Parse(context.Background(), test.input, &event.Mentions{})
 			if err != nil {
 				t.Fatal(err)
 			}
 			if output != test.expected {
 				t.Fatalf("unexpected output: %q", output)
+			}
+			if requestedID != test.expectedID {
+				t.Fatalf("unexpected requested ID: got %q, want %q", requestedID, test.expectedID)
 			}
 		})
 	}

--- a/pkg/msgconv/mrkdwn/tag_test.go
+++ b/pkg/msgconv/mrkdwn/tag_test.go
@@ -1,0 +1,55 @@
+// mautrix-slack - A Matrix-Slack puppeting bridge.
+// Copyright (C) 2024 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package mrkdwn
+
+import (
+	"context"
+	"testing"
+
+	"maunium.net/go/mautrix/event"
+)
+
+func TestUserGroupMention(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "embedded label",
+			input:    "Hi <!subteam^S123|@platform-team>",
+			expected: "Hi @platform-team",
+		},
+		{
+			name:     "raw fallback",
+			input:    "Hi <!subteam^S404>",
+			expected: "Hi &lt;!subteam^S404&gt;",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parser := New(&Params{})
+			output, err := parser.Parse(context.Background(), test.input, &event.Mentions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if output != test.expected {
+				t.Fatalf("unexpected output: %q", output)
+			}
+		})
+	}
+}

--- a/pkg/msgconv/msgconv.go
+++ b/pkg/msgconv/msgconv.go
@@ -18,6 +18,7 @@ package msgconv
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"time"
@@ -56,6 +57,7 @@ type SlackClientProvider interface {
 	GetClient() *slack.Client
 	GetEmoji(context.Context, string) (string, bool)
 	GetChannelInfoForMention(context.Context, string) (string, *bridgev2.Portal, error)
+	GetUserGroupInfoForMention(context.Context, string) (string, error)
 }
 
 func (mc *MessageConverter) GetMentionedUserInfo(ctx context.Context, userID string) (mxid id.UserID, name string) {
@@ -100,6 +102,22 @@ func (mc *MessageConverter) GetMentionedRoomInfo(ctx context.Context, channelID 
 	}
 }
 
+func (mc *MessageConverter) GetMentionedUserGroupInfo(ctx context.Context, userGroupID string) (name string) {
+	source, _ := ctx.Value(contextKeySource).(*bridgev2.UserLogin)
+	if source == nil {
+		return
+	}
+	client, ok := source.Client.(SlackClientProvider)
+	if !ok {
+		return
+	}
+	name, err := client.GetUserGroupInfoForMention(ctx, userGroupID)
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		zerolog.Ctx(ctx).Err(err).Str("user_group_id", userGroupID).Msg("Failed to get info of mentioned user group")
+	}
+	return
+}
+
 func New(br *bridgev2.Bridge, db *slackdb.SlackDB) *MessageConverter {
 	mc := &MessageConverter{
 		Bridge: br,
@@ -119,9 +137,10 @@ func New(br *bridgev2.Bridge, db *slackdb.SlackDB) *MessageConverter {
 		MatrixHTMLParser: matrixfmt.New2(br, db),
 	}
 	mc.SlackMrkdwnParser = mrkdwn.New(&mrkdwn.Params{
-		ServerName:     br.Matrix.ServerName(),
-		GetUserInfo:    mc.GetMentionedUserInfo,
-		GetChannelInfo: mc.GetMentionedRoomInfo,
+		ServerName:       br.Matrix.ServerName(),
+		GetUserInfo:      mc.GetMentionedUserInfo,
+		GetChannelInfo:   mc.GetMentionedRoomInfo,
+		GetUserGroupInfo: mc.GetMentionedUserGroupInfo,
 	})
 	return mc
 }


### PR DESCRIPTION
Built on #91. Until #91 merges, GitHub shows both commits in this PR; after it merges, this PR becomes the resolver-only follow-up.

## What this adds

- Lazily calls `usergroups.list` only when an unlabeled user-group mention must be resolved.
- Shares a workspace-wide handle cache between mrkdwn and rich-text block conversion.
- Refreshes the cache after one hour so renamed, added, and removed groups are picked up.
- Bounds API calls to 10 seconds, backs off failed refreshes for one minute, and retains stale handles when Slack is temporarily unavailable.
- Falls back to the visible raw `<!subteam^ID>` form when no handle can be resolved.
- Adds `usergroups:read` to the bot app manifest.

This does not add a synchronous lookup during connection startup or subscribe to user-group events. The first unlabeled group mention may perform one bounded lookup; cache hits do not call Slack.

## Authentication impact

Cookie-backed `xoxc` user sessions were tested against `usergroups.list` successfully and do not use the bot app manifest. Existing `xoxb` bot installations must be reauthorized/reinstalled to grant the new `usergroups:read` scope.

## Verification

- `go test -count=1 ./pkg/connector ./pkg/msgconv/...`
- `go test -race -count=1 ./pkg/connector ./pkg/msgconv/...`
- `go vet ./pkg/connector ./pkg/msgconv/...`

Tests cover embedded labels, resolved and unresolved mrkdwn mentions, rich-text user-group elements, cache hits and expiry, stale-data retention, retry backoff, and canceled contexts.