### PR TITLE
login: don't fail login if fetching version data fails

### DIFF
--- a/pkg/connector/login-cookie.go
+++ b/pkg/connector/login-cookie.go
@@ -138,10 +138,8 @@ func (s *SlackTokenLogin) Cancel() {}
 func (s *SlackTokenLogin) SubmitCookies(ctx context.Context, input map[string]string) (*bridgev2.LoginStep, error) {
 	token, cookieToken := input["auth_token"], input["cookie_token"]
 	client := makeSlackClient(&s.User.Log, token, cookieToken, "")
-	err := client.FetchVersionData(ctx)
-	if err != nil {
+	if err := client.FetchVersionData(ctx); err != nil {
 		zerolog.Ctx(ctx).Warn().Err(err).Msg("Failed to fetch version data")
-		return nil, err
 	}
 	info, err := client.ClientUserBootContext(ctx, time.Time{})
 	if err != nil {


### PR DESCRIPTION
Version data is optional decoration on client.userBoot query params and is already treated as non-fatal when connecting. Gating login on it discards a valid session before client.boot, the actual credential check, ever runs.

