### PR TITLE
directmedia: add support for custom emoji

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -18,6 +18,7 @@ package connector
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/slack-go/slack"
 	"maunium.net/go/mautrix"
@@ -32,11 +33,14 @@ type SlackConnector struct {
 	Config  Config
 	DB      *slackdb.SlackDB
 	MsgConv *msgconv.MessageConverter
+
+	useDirectMedia atomic.Bool
 }
 
 var (
 	_ bridgev2.NetworkConnector      = (*SlackConnector)(nil)
 	_ bridgev2.MaxFileSizeingNetwork = (*SlackConnector)(nil)
+	_ bridgev2.DirectMediableNetwork = (*SlackConnector)(nil)
 )
 
 func (s *SlackConnector) Init(bridge *bridgev2.Bridge) {
@@ -49,6 +53,10 @@ func (s *SlackConnector) Init(bridge *bridgev2.Bridge) {
 
 func (s *SlackConnector) SetMaxFileSize(maxSize int64) {
 	s.MsgConv.MaxFileSize = int(maxSize)
+}
+
+func (s *SlackConnector) SetUseDirectMedia() {
+	s.useDirectMedia.Store(true)
 }
 
 func (s *SlackConnector) Start(ctx context.Context) error {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -18,7 +18,6 @@ package connector
 
 import (
 	"context"
-	"sync/atomic"
 
 	"github.com/slack-go/slack"
 	"maunium.net/go/mautrix"
@@ -34,7 +33,7 @@ type SlackConnector struct {
 	DB      *slackdb.SlackDB
 	MsgConv *msgconv.MessageConverter
 
-	useDirectMedia atomic.Bool
+	directMedia bool
 }
 
 var (
@@ -56,7 +55,7 @@ func (s *SlackConnector) SetMaxFileSize(maxSize int64) {
 }
 
 func (s *SlackConnector) SetUseDirectMedia() {
-	s.useDirectMedia.Store(true)
+	s.directMedia = true
 }
 
 func (s *SlackConnector) Start(ctx context.Context) error {

--- a/pkg/connector/directmedia.go
+++ b/pkg/connector/directmedia.go
@@ -19,7 +19,6 @@ package connector
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 
@@ -51,31 +50,12 @@ func parseSlackEmojiMediaID(mediaID networkid.MediaID) (*url.URL, error) {
 	return parsed, nil
 }
 
-func (s *SlackConnector) Download(ctx context.Context, mediaID networkid.MediaID, _ map[string]string) (mediaproxy.GetMediaResponse, error) {
+func (s *SlackConnector) Download(_ context.Context, mediaID networkid.MediaID, _ map[string]string) (mediaproxy.GetMediaResponse, error) {
 	emojiURL, err := parseSlackEmojiMediaID(mediaID)
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, emojiURL.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to prepare Slack emoji request: %w", err)
-	}
-	client := s.MsgConv.HTTP
-	client.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
-		_, err := parseSlackEmojiMediaID(makeSlackEmojiMediaID(req.URL.String()))
-		return err
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download Slack emoji: %w", err)
-	}
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		_ = resp.Body.Close()
-		return nil, fmt.Errorf("failed to download Slack emoji: HTTP %d", resp.StatusCode)
-	}
-	return &mediaproxy.GetMediaResponseData{
-		Reader:        resp.Body,
-		ContentType:   resp.Header.Get("Content-Type"),
-		ContentLength: resp.ContentLength,
+	return &mediaproxy.GetMediaResponseURL{
+		URL: emojiURL.String(),
 	}, nil
 }

--- a/pkg/connector/directmedia.go
+++ b/pkg/connector/directmedia.go
@@ -1,0 +1,81 @@
+// mautrix-slack - A Matrix-Slack puppeting bridge.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package connector
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"maunium.net/go/mautrix/bridgev2/networkid"
+	"maunium.net/go/mautrix/mediaproxy"
+)
+
+const (
+	slackEmojiMediaIDPrefix = "emoji:"
+	slackEmojiMediaHost     = "emoji.slack-edge.com"
+)
+
+func makeSlackEmojiMediaID(emojiURL string) networkid.MediaID {
+	return networkid.MediaID(slackEmojiMediaIDPrefix + emojiURL)
+}
+
+func parseSlackEmojiMediaID(mediaID networkid.MediaID) (*url.URL, error) {
+	rawURL, ok := strings.CutPrefix(string(mediaID), slackEmojiMediaIDPrefix)
+	if !ok {
+		return nil, fmt.Errorf("unknown Slack media ID type")
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Slack emoji URL: %w", err)
+	}
+	if parsed.Scheme != "https" || !strings.EqualFold(parsed.Hostname(), slackEmojiMediaHost) || parsed.User != nil {
+		return nil, fmt.Errorf("invalid Slack emoji URL host")
+	}
+	return parsed, nil
+}
+
+func (s *SlackConnector) Download(ctx context.Context, mediaID networkid.MediaID, _ map[string]string) (mediaproxy.GetMediaResponse, error) {
+	emojiURL, err := parseSlackEmojiMediaID(mediaID)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, emojiURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare Slack emoji request: %w", err)
+	}
+	client := s.MsgConv.HTTP
+	client.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
+		_, err := parseSlackEmojiMediaID(makeSlackEmojiMediaID(req.URL.String()))
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download Slack emoji: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("failed to download Slack emoji: HTTP %d", resp.StatusCode)
+	}
+	return &mediaproxy.GetMediaResponseData{
+		Reader:        resp.Body,
+		ContentType:   resp.Header.Get("Content-Type"),
+		ContentLength: resp.ContentLength,
+	}, nil
+}

--- a/pkg/connector/directmedia.go
+++ b/pkg/connector/directmedia.go
@@ -19,43 +19,125 @@ package connector
 import (
 	"context"
 	"fmt"
-	"net/url"
+	"slices"
 	"strings"
 
 	"maunium.net/go/mautrix/bridgev2/networkid"
 	"maunium.net/go/mautrix/mediaproxy"
 )
 
+type MediaIDType byte
+
 const (
-	slackEmojiMediaIDPrefix = "emoji:"
-	slackEmojiMediaHost     = "emoji.slack-edge.com"
+	MediaIDTypeEmoji MediaIDType = 1
 )
 
-func makeSlackEmojiMediaID(emojiURL string) networkid.MediaID {
-	return networkid.MediaID(slackEmojiMediaIDPrefix + emojiURL)
-}
-
-func parseSlackEmojiMediaID(mediaID networkid.MediaID) (*url.URL, error) {
-	rawURL, ok := strings.CutPrefix(string(mediaID), slackEmojiMediaIDPrefix)
-	if !ok {
-		return nil, fmt.Errorf("unknown Slack media ID type")
-	}
-	parsed, err := url.Parse(rawURL)
-	if err != nil {
-		return nil, fmt.Errorf("invalid Slack emoji URL: %w", err)
-	}
-	if parsed.Scheme != "https" || !strings.EqualFold(parsed.Hostname(), slackEmojiMediaHost) || parsed.User != nil {
-		return nil, fmt.Errorf("invalid Slack emoji URL host")
-	}
-	return parsed, nil
-}
-
 func (s *SlackConnector) Download(_ context.Context, mediaID networkid.MediaID, _ map[string]string) (mediaproxy.GetMediaResponse, error) {
-	emojiURL, err := parseSlackEmojiMediaID(mediaID)
+	rawParsedID, err := ParseMediaID(mediaID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse media ID: %w", err)
 	}
-	return &mediaproxy.GetMediaResponseURL{
-		URL: emojiURL.String(),
-	}, nil
+	switch parsedID := rawParsedID.(type) {
+	case *DirectMediaEmoji:
+		return &mediaproxy.GetMediaResponseURL{
+			URL: parsedID.URL(),
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown media ID type: %T", parsedID)
+	}
+}
+
+func ParseMediaID(mediaID networkid.MediaID) (any, error) {
+	if len(mediaID) == 0 {
+		return nil, fmt.Errorf("empty media ID")
+	}
+	mediaIDType := MediaIDType(mediaID[0])
+	mediaID = mediaID[1:]
+	switch mediaIDType {
+	case MediaIDTypeEmoji:
+		teamID, mediaID, err := readShortString(mediaID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read team ID: %w", err)
+		}
+		emojiID, mediaID, err := readShortString(mediaID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read emoji ID: %w", err)
+		}
+		fileName, _, err := readShortString(mediaID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file name: %w", err)
+		}
+		return &DirectMediaEmoji{
+			TeamID:   teamID,
+			EmojiID:  emojiID,
+			FileName: fileName,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown media ID type: %d", mediaIDType)
+	}
+}
+
+const slackEmojiURLPrefix = "https://emoji.slack-edge.com/"
+
+type DirectMediaEmoji struct {
+	TeamID   string
+	EmojiID  string
+	FileName string
+}
+
+func DirectMediaEmojiFromURL(url string) *DirectMediaEmoji {
+	data, ok := strings.CutPrefix(url, slackEmojiURLPrefix)
+	if !ok {
+		return nil
+	}
+	parts := strings.Split(data, "/")
+	if len(parts) != 3 {
+		return nil
+	}
+	teamID := parts[0]
+	emojiID := parts[1]
+	fileName := parts[2]
+	if len(teamID) > 16 || len(emojiID) > 100 || len(fileName) > 32 {
+		return nil
+	}
+	return &DirectMediaEmoji{
+		TeamID:   teamID,
+		EmojiID:  emojiID,
+		FileName: fileName,
+	}
+}
+
+func (dme *DirectMediaEmoji) URL() string {
+	if dme == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s%s/%s/%s", slackEmojiURLPrefix, dme.TeamID, dme.EmojiID, dme.FileName)
+}
+
+func (dme *DirectMediaEmoji) MediaID() networkid.MediaID {
+	if dme == nil || len(dme.TeamID) > 16 || len(dme.EmojiID) > 100 || len(dme.FileName) > 32 {
+		return nil
+	}
+	return slices.Concat(
+		[]byte{byte(MediaIDTypeEmoji)},
+		[]byte{byte(len(dme.TeamID))},
+		[]byte(dme.TeamID),
+		[]byte{byte(len(dme.EmojiID))},
+		[]byte(dme.EmojiID),
+		[]byte{byte(len(dme.FileName))},
+		[]byte(dme.FileName),
+	)
+}
+
+func readShortString(input []byte) (value string, remaining []byte, err error) {
+	if len(input) == 0 {
+		return "", nil, fmt.Errorf("input is empty")
+	}
+	length := int(input[0])
+	if len(input) < 1+length {
+		return "", nil, fmt.Errorf("input is too short for length %d", length)
+	}
+	value = string(input[1 : 1+length])
+	remaining = input[1+length:]
+	return
 }

--- a/pkg/connector/emoji.go
+++ b/pkg/connector/emoji.go
@@ -185,7 +185,16 @@ func downloadPlainFile(ctx context.Context, url, thing string) ([]byte, error) {
 	return data, nil
 }
 
-func reuploadEmoji(ctx context.Context, intent bridgev2.MatrixAPI, url string) (id.ContentURIString, error) {
+func (s *SlackConnector) reuploadEmoji(ctx context.Context, intent bridgev2.MatrixAPI, url string) (id.ContentURIString, error) {
+	if s.directMedia {
+		mediaID := DirectMediaEmojiFromURL(url).MediaID()
+		if mediaID != nil {
+			return s.br.Matrix.GenerateContentURI(ctx, mediaID)
+		}
+		zerolog.Ctx(ctx).Warn().
+			Str("url", url).
+			Msg("Unsupported custom emoji URL for direct media, falling back to upload")
+	}
 	data, err := downloadPlainFile(ctx, url, "emoji")
 	if err != nil {
 		return "", err
@@ -308,15 +317,6 @@ func (s *SlackClient) tryGetEmoji(ctx context.Context, shortcode string, ensureU
 		return
 	}
 	found = true
-	if s.Main.useDirectMedia.Load() && !strings.HasPrefix(dbEmoji.Value, "alias:") {
-		valURI, directMediaErr := s.Main.br.Matrix.GenerateContentURI(ctx, makeSlackEmojiMediaID(dbEmoji.Value))
-		if directMediaErr == nil {
-			return string(valURI), true, true
-		}
-		zerolog.Ctx(ctx).Warn().Err(directMediaErr).
-			Str("shortcode", shortcode).
-			Msg("Failed to generate direct media URI for custom emoji, falling back to upload")
-	}
 	if dbEmoji.ImageMXC != "" {
 		val = string(dbEmoji.ImageMXC)
 		isImage = true
@@ -328,7 +328,7 @@ func (s *SlackClient) tryGetEmoji(ctx context.Context, shortcode string, ensureU
 		val, isImage, _ = s.tryGetEmoji(ctx, strings.TrimPrefix(dbEmoji.Value, "alias:"), ensureUploaded, false)
 	} else if ensureUploaded {
 		defer s.Main.DB.Emoji.WithLock(s.TeamID)()
-		dbEmoji.ImageMXC, err = reuploadEmoji(ctx, s.Main.br.Bot, dbEmoji.Value)
+		dbEmoji.ImageMXC, err = s.Main.reuploadEmoji(ctx, s.Main.br.Bot, dbEmoji.Value)
 		if err != nil {
 			zerolog.Ctx(ctx).Err(err).
 				Str("shortcode", shortcode).

--- a/pkg/connector/emoji.go
+++ b/pkg/connector/emoji.go
@@ -308,6 +308,15 @@ func (s *SlackClient) tryGetEmoji(ctx context.Context, shortcode string, ensureU
 		return
 	}
 	found = true
+	if s.Main.useDirectMedia.Load() && !strings.HasPrefix(dbEmoji.Value, "alias:") {
+		valURI, directMediaErr := s.Main.br.Matrix.GenerateContentURI(ctx, makeSlackEmojiMediaID(dbEmoji.Value))
+		if directMediaErr == nil {
+			return string(valURI), true, true
+		}
+		zerolog.Ctx(ctx).Warn().Err(directMediaErr).
+			Str("shortcode", shortcode).
+			Msg("Failed to generate direct media URI for custom emoji, falling back to upload")
+	}
 	if dbEmoji.ImageMXC != "" {
 		val = string(dbEmoji.ImageMXC)
 		isImage = true

--- a/pkg/connector/emoji.go
+++ b/pkg/connector/emoji.go
@@ -38,6 +38,9 @@ var _ bridgev2.StickerImportingNetworkAPI = (*SlackClient)(nil)
 const StickerSourceID = "slack"
 
 func (s *SlackClient) DownloadImagePack(ctx context.Context, url string) (*bridgev2.ImportedImagePack, error) {
+	if s.BootResp == nil {
+		return nil, bridgev2.ErrNotLoggedIn
+	}
 	if !strings.Contains(url, s.BootResp.Team.Domain) {
 		return nil, fmt.Errorf("image pack url must contain team domain (%s)", s.BootResp.Team.Domain)
 	}
@@ -80,6 +83,9 @@ func (s *SlackClient) workspaceImagePackMeta() *event.ImagePackMetadata {
 }
 
 func (s *SlackClient) ListImagePacks(ctx context.Context) ([]*event.ImagePackMetadata, error) {
+	if s.BootResp == nil {
+		return nil, bridgev2.ErrNotLoggedIn
+	}
 	return []*event.ImagePackMetadata{s.workspaceImagePackMeta()}, nil
 }
 

--- a/pkg/connector/handlematrix.go
+++ b/pkg/connector/handlematrix.go
@@ -179,8 +179,11 @@ func (s *SlackClient) PreHandleMatrixReaction(ctx context.Context, msg *bridgev2
 		dbEmoji, err = s.Main.DB.Emoji.GetByMXC(ctx, key)
 		if err != nil {
 			err = fmt.Errorf("failed to get emoji from db: %w", err)
+		} else if dbEmoji == nil {
+			err = fmt.Errorf("unknown emoji %q", key)
+		} else {
+			emojiID = dbEmoji.EmojiID
 		}
-		emojiID = dbEmoji.EmojiID
 	} else {
 		emojiID = emoji.GetShortcode(key)
 		if emojiID == "" {


### PR DESCRIPTION
needed for local slack

~~had to revert usage of [GetMediaResponseURL](https://github.com/mautrix/slack/commit/c11b52e5d4e36d10bf4b6b2457f125d6f51bb37f) since unimplemented in sdk~~