### PR TITLE
client: fix nil client panic in user resync loop after disconnect

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -277,7 +277,7 @@ func (s *SlackClient) connect(ctx context.Context, bootResp *slack.ClientUserBoo
 	if s.IsRealUser {
 		go s.consumeRTMEvents()
 		go s.RTM.ManageConnection()
-		go s.resyncUsers()
+		s.startUserResync()
 	} else {
 		go s.consumeSocketModeEvents()
 		go s.runSocketMode(ctx)
@@ -303,44 +303,49 @@ func (s *SlackClient) consumeSocketModeEvents() {
 	}
 }
 
-func (s *SlackClient) resyncUsers() {
+func (s *SlackClient) startUserResync() {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ctx = s.UserLogin.Log.With().Str("component", "user resync loop").Logger().WithContext(ctx)
 	if cancelOld := s.stopResyncQueue.Swap(&cancel); cancelOld != nil {
 		(*cancelOld)()
 	}
+	go s.resyncUsers(ctx)
+}
+
+func (s *SlackClient) resyncUsers(ctx context.Context) {
+	ctx = s.UserLogin.Log.With().Str("component", "user resync loop").Logger().WithContext(ctx)
 	const resyncWait = 30 * time.Second
 	const shortResyncWait = 1 * time.Second
+	var entries map[string]*bridgev2.Ghost
+	var timer *time.Timer
+	var timerC <-chan time.Time
 	forceShortWait := false
-	for entry := range s.userResyncQueue {
-		_, userID := slackid.ParseUserID(entry.ID)
-		entries := map[string]*bridgev2.Ghost{userID: entry}
-		var timer *time.Timer
-		if entry.Name == "" || forceShortWait {
-			forceShortWait = true
-			timer = time.NewTimer(shortResyncWait)
-		} else {
-			timer = time.NewTimer(resyncWait)
-		}
-	CollectLoop:
-		for {
-			select {
-			case entry = <-s.userResyncQueue:
-				_, userID = slackid.ParseUserID(entry.ID)
-				entries[userID] = entry
-				if entry.Name == "" || forceShortWait {
-					forceShortWait = true
-					timer.Reset(shortResyncWait)
-				} else {
-					timer.Reset(resyncWait)
-				}
-			case <-timer.C:
-				break CollectLoop
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case entry := <-s.userResyncQueue:
+			_, userID := slackid.ParseUserID(entry.ID)
+			if entries == nil {
+				entries = make(map[string]*bridgev2.Ghost)
 			}
+			entries[userID] = entry
+			wait := resyncWait
+			if entry.Name == "" || forceShortWait {
+				forceShortWait = true
+				wait = shortResyncWait
+			}
+			if timer == nil {
+				timer = time.NewTimer(wait)
+			} else {
+				timer.Reset(wait)
+			}
+			timerC = timer.C
+		case <-timerC:
+			go s.syncManyUsers(ctx, entries)
+			entries = nil
+			timerC = nil
+			forceShortWait = false
 		}
-		go s.syncManyUsers(ctx, entries)
-		forceShortWait = false
 	}
 }
 
@@ -600,7 +605,6 @@ func (s *SlackClient) syncChannels(ctx context.Context, channels []*slack.Channe
 
 func (s *SlackClient) Disconnect() {
 	s.disconnect()
-	s.Client = nil
 }
 
 func (s *SlackClient) disconnect() {
@@ -651,6 +655,7 @@ func (s *SlackClient) invalidateSession(ctx context.Context, state status.Bridge
 		zerolog.Ctx(ctx).Err(err).Msg("Failed to save user login after invalidating session")
 	}
 	s.Disconnect()
+	s.Client = nil
 	s.UserLogin.BridgeState.Send(state)
 }
 


### PR DESCRIPTION
## Problem

`Disconnect()` set `s.Client` to nil, but the user resync loop started in `connect()` never checked its context and kept running. The next ghost queued via `GetUserInfo` was flushed to `syncManyUsers`, which dereferenced the nil client:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x35b162d20]

goroutine 454948 [running]:
github.com/slack-go/slack.(*Client).GetUsersCacheContext(0x0, {0x3602c45b0, 0x4294be278de0}, {0x4294ba6648b8, 0x9}, {0x1, 0x1, {0x0, 0x0}, 0x4294bcb3dc80})
	/Users/kb/go/pkg/mod/github.com/beeper/slackgo@v0.0.0-20260810175010-b487515492cf/users.go:524 +0x40
go.mau.fi/mautrix-slack/pkg/connector.(*SlackClient).syncManyUsers(0x4294b9f3f100, {0x3602c45b0, 0x4294be278de0}, 0x4294bb98c960)
	/Users/kb/go/pkg/mod/go.mau.fi/mautrix-slack@v0.2608.0/pkg/connector/chatinfo.go:501 +0x160
created by go.mau.fi/mautrix-slack/pkg/connector.(*SlackClient).resyncUsers in goroutine 282392
	/Users/kb/go/pkg/mod/go.mau.fi/mautrix-slack@v0.2608.0/pkg/connector/client.go:342 +0x2e0
```

## Fix

- **Keep `s.Client` non-nil across `Disconnect()`.** bridgev2 disconnects a `SlackClient` at most once (guarded by `disconnectOnce`) and builds a fresh one via `LoadUserLogin` on reconnect, so nothing reuses a disconnected client. The `IsLoggedIn` interface doc defines it as token validity, not connection state, so it should stay true after a plain disconnect. This also removes the same latent nil deref from every other goroutine that can outlive a disconnect (`syncChannels`, `SyncEmojis`, RTM event handlers, `fetchUserInfo`).
- **Nil the client only when tokens are invalidated.** `LogoutRemote` already did this; `invalidateSession` now does too, so the not-logged-in paths in the Matrix handlers still fire after Slack rejects the session.
- **Make the resync loop exit on cancel.** `startUserResync` swaps the cancel func synchronously in `connect()` and spawns the loop; the loop returns on `ctx.Done()`, so `disconnect()` actually stops it instead of leaking one loop per reconnect. The loop body is collapsed into a single `select` with a nil timer channel standing in for "no batch pending", same batching behavior as before.

## Not covered

- `GetUserInfo` still does a blocking send on the resync queue. After the loop exits (post-`invalidateSession`/`LogoutRemote`) the 16-slot buffer can fill and block callers. This previously panicked, so it is strictly better, but a nil-client guard there would close it fully.
- A flush already in flight when `LogoutRemote`/`invalidateSession` nils the client can still see nil. Narrow and pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEA5sW7AHo2eJCjZvdA3Ux
