### PR TITLE
Set length hints on the 2FA and email code login fields

### DIFF
--- a/pkg/connector/login-email.go
+++ b/pkg/connector/login-email.go
@@ -391,6 +391,8 @@ func slackEmailCodeStep(instructions string) *bridgev2.LoginStep {
 				Name:        "Confirmation code",
 				Description: "Six-character code from Slack",
 				Pattern:     `^[a-zA-Z0-9]{3}-?[a-zA-Z0-9]{3}$`,
+				MinLength:   6,
+				MaxLength:   7,
 			}},
 		},
 	}
@@ -425,6 +427,8 @@ func slackTwoFactorStep(instructions string) *bridgev2.LoginStep {
 				Name:        "Authentication code",
 				Description: "Six-digit code from your Slack authenticator or SMS",
 				Pattern:     slackLoginTwoFactorCodeRegex,
+				MinLength:   6,
+				MaxLength:   6,
 			}},
 		},
 	}


### PR DESCRIPTION
Sets `MinLength`/`MaxLength` on the authenticator code (6) and email confirmation code (6 to 7, allowing the optional dash) so clients can cap the input rather than only failing the regex.

Depends on the mautrix-go change adding those fields to `LoginInputDataField`: https://github.com/SilverBirchh/go/tree/login-field-length. Needs a go.mod bump once that merges.